### PR TITLE
fix: FastImage borderRadius animation

### DIFF
--- a/lib/android/app/src/main/java/com/reactnativenavigation/views/element/animators/FastImageBorderRadiusAnimator+utilities.kt
+++ b/lib/android/app/src/main/java/com/reactnativenavigation/views/element/animators/FastImageBorderRadiusAnimator+utilities.kt
@@ -4,8 +4,10 @@ import android.view.View
 import android.view.ViewGroup
 import com.facebook.react.views.view.ReactViewGroup
 import com.reactnativenavigation.R
+import com.reactnativenavigation.react.ReactView
 import com.reactnativenavigation.utils.ViewTags
 import com.reactnativenavigation.utils.borderRadius
+import com.reactnativenavigation.viewcontrollers.viewcontroller.overlay.OverlayLayout
 
 /**
  * Gets the border radius for a react-native-fast-image view that

--- a/lib/android/app/src/main/java/com/reactnativenavigation/views/element/animators/FastImageBorderRadiusAnimator+utilities.kt
+++ b/lib/android/app/src/main/java/com/reactnativenavigation/views/element/animators/FastImageBorderRadiusAnimator+utilities.kt
@@ -41,7 +41,7 @@ private fun getBorderRadius(v: View): Float {
 
 private fun getParent(view: View): ViewGroup? = try {
     when(view.parent) {
-        null -> null
+        null, is ReactView, is OverlayLayout -> null
         else -> ViewTags.get<ViewGroup>(view, R.id.original_parent, view.parent as ViewGroup)
     }
 // TODO: can we handle this better?: java.lang.ClassCastException: android.view.ViewRootImpl cannot be cast to android.view.ViewGroup

--- a/lib/android/app/src/main/java/com/reactnativenavigation/views/element/animators/FastImageBorderRadiusAnimator+utilities.kt
+++ b/lib/android/app/src/main/java/com/reactnativenavigation/views/element/animators/FastImageBorderRadiusAnimator+utilities.kt
@@ -1,0 +1,71 @@
+package com.reactnativenavigation.views.element.animators
+
+import android.view.View
+import android.view.ViewGroup
+import androidx.core.view.children
+import com.facebook.react.views.view.ReactViewBackgroundDrawable
+import com.facebook.react.views.view.ReactViewGroup
+import com.reactnativenavigation.R
+import com.reactnativenavigation.utils.ViewTags
+import com.reactnativenavigation.utils.borderRadius
+import com.reactnativenavigation.viewcontrollers.viewcontroller.overlay.OverlayLayout
+import java.lang.ClassCastException
+
+/**
+ * Gets the border radius for a react-native-fast-image view that
+ * is eventually embedded in other components. It might be the case
+ * that the FastImage doesn't have a border radius, in this case
+ * a inherited border radius will be looked up. Example of such a case
+ *
+ * @example
+ *
+ * <View style={{ borderRadius: 30, overflow: "hidden" }}>
+ *     <FastImage {...} />
+ * </View>
+ */
+fun FastImageBorderRadiusAnimator.getInheritedBorderRadius(v: View): Float {
+    val borderRadius = getBorderRadius(v)
+    if (borderRadius > 0f) {
+        return borderRadius
+    }
+
+    return when(val parentView = getParent(v)) {
+        null -> 0f
+        else -> getInheritedBorderRadius(parentView)
+    }
+}
+
+private fun getBorderRadius(v: View): Float {
+    // gets the border radius from a react view
+    if (v is ReactViewGroup && v.borderRadius > 0f) {
+        return v.borderRadius
+    }
+
+    // gets the border radius for a FastImage view
+    return getBorderRadiusFastImage(v);
+}
+
+private fun getBorderRadiusFastImage(v: View): Float {
+    val parentView = getParent(v)
+
+    if (parentView == null || v is OverlayLayout) {
+        return 0f
+    }
+
+    val parentIsUsedOnlyToDrawBorderRadiusOverImage = parentView.childCount <= 1 || parentView.children.contains(v)
+    val background = parentView.background as? ReactViewBackgroundDrawable
+    if (parentIsUsedOnlyToDrawBorderRadiusOverImage && background?.hasRoundedBorders() == true) {
+        background.fullBorderRadius
+    }
+    return 0f
+}
+
+private fun getParent(view: View): ViewGroup? = try {
+    when(view.parent) {
+        null -> null
+        else -> ViewTags.get<ViewGroup>(view, R.id.original_parent, view.parent as ViewGroup)
+    }
+// TODO: can we handle this better?: java.lang.ClassCastException: android.view.ViewRootImpl cannot be cast to android.view.ViewGroup
+} catch (e: ClassCastException) {
+    null
+}

--- a/lib/android/app/src/main/java/com/reactnativenavigation/views/element/animators/FastImageBorderRadiusAnimator+utilities.kt
+++ b/lib/android/app/src/main/java/com/reactnativenavigation/views/element/animators/FastImageBorderRadiusAnimator+utilities.kt
@@ -21,9 +21,7 @@ import com.reactnativenavigation.utils.borderRadius
  */
 fun FastImageBorderRadiusAnimator.getInheritedBorderRadius(v: View): Float {
     val borderRadius = getBorderRadius(v)
-    if (borderRadius > 0f) {
-        return borderRadius
-    }
+    if (borderRadius > 0f) return borderRadius
 
     return when(val parentView = getParent(v)) {
         null -> 0f

--- a/lib/android/app/src/main/java/com/reactnativenavigation/views/element/animators/FastImageBorderRadiusAnimator+utilities.kt
+++ b/lib/android/app/src/main/java/com/reactnativenavigation/views/element/animators/FastImageBorderRadiusAnimator+utilities.kt
@@ -2,14 +2,10 @@ package com.reactnativenavigation.views.element.animators
 
 import android.view.View
 import android.view.ViewGroup
-import androidx.core.view.children
-import com.facebook.react.views.view.ReactViewBackgroundDrawable
 import com.facebook.react.views.view.ReactViewGroup
 import com.reactnativenavigation.R
 import com.reactnativenavigation.utils.ViewTags
 import com.reactnativenavigation.utils.borderRadius
-import com.reactnativenavigation.viewcontrollers.viewcontroller.overlay.OverlayLayout
-import java.lang.ClassCastException
 
 /**
  * Gets the border radius for a react-native-fast-image view that
@@ -36,28 +32,13 @@ fun FastImageBorderRadiusAnimator.getInheritedBorderRadius(v: View): Float {
 }
 
 private fun getBorderRadius(v: View): Float {
-    // gets the border radius from a react view
-    if (v is ReactViewGroup && v.borderRadius > 0f) {
+    // checking if the view has borderRadius and overflow hidden.
+    // when the overflow isn't hidden the borderRadius wouldn't apply.
+    if (v is ReactViewGroup && v.borderRadius > 0f && v.overflow == "hidden") {
         return v.borderRadius
     }
 
-    // gets the border radius for a FastImage view
-    return getBorderRadiusFastImage(v);
-}
-
-private fun getBorderRadiusFastImage(v: View): Float {
-    val parentView = getParent(v)
-
-    if (parentView == null || v is OverlayLayout) {
-        return 0f
-    }
-
-    val parentIsUsedOnlyToDrawBorderRadiusOverImage = parentView.childCount <= 1 || parentView.children.contains(v)
-    val background = parentView.background as? ReactViewBackgroundDrawable
-    if (parentIsUsedOnlyToDrawBorderRadiusOverImage && background?.hasRoundedBorders() == true) {
-        background.fullBorderRadius
-    }
-    return 0f
+    return 0f;
 }
 
 private fun getParent(view: View): ViewGroup? = try {

--- a/lib/android/app/src/main/java/com/reactnativenavigation/views/element/animators/FastImageBorderRadiusAnimator+utilities.kt
+++ b/lib/android/app/src/main/java/com/reactnativenavigation/views/element/animators/FastImageBorderRadiusAnimator+utilities.kt
@@ -25,7 +25,11 @@ fun FastImageBorderRadiusAnimator.getInheritedBorderRadius(v: View): Float {
     val borderRadius = getBorderRadius(v)
     if (borderRadius > 0f) return borderRadius
 
-    return when(val parentView = getParent(v)) {
+    if (v is ReactView || v is OverlayLayout) {
+        return 0f
+    }
+
+    return when(val parentView = getOriginalParent(v)) {
         null -> 0f
         else -> getInheritedBorderRadius(parentView)
     }
@@ -41,12 +45,7 @@ private fun getBorderRadius(v: View): Float {
     return 0f;
 }
 
-private fun getParent(view: View): ViewGroup? = try {
-    when(view.parent) {
-        null, is ReactView, is OverlayLayout -> null
-        else -> ViewTags.get<ViewGroup>(view, R.id.original_parent, view.parent as ViewGroup)
-    }
-// TODO: can we handle this better?: java.lang.ClassCastException: android.view.ViewRootImpl cannot be cast to android.view.ViewGroup
-} catch (e: ClassCastException) {
-    null
+private fun getOriginalParent(view: View): ViewGroup? = when(view.parent) {
+    null -> null
+    else -> ViewTags.get<ViewGroup>(view, R.id.original_parent, view.parent as ViewGroup)
 }

--- a/lib/android/app/src/main/java/com/reactnativenavigation/views/element/animators/FastImageBorderRadiusAnimator+utilities.kt
+++ b/lib/android/app/src/main/java/com/reactnativenavigation/views/element/animators/FastImageBorderRadiusAnimator+utilities.kt
@@ -22,12 +22,12 @@ import com.reactnativenavigation.viewcontrollers.viewcontroller.overlay.OverlayL
  * </View>
  */
 fun FastImageBorderRadiusAnimator.getInheritedBorderRadius(v: View): Float {
-    val borderRadius = getBorderRadius(v)
-    if (borderRadius > 0f) return borderRadius
-
     if (v is ReactView || v is OverlayLayout) {
         return 0f
     }
+
+    val borderRadius = getBorderRadius(v)
+    if (borderRadius > 0f) return borderRadius
 
     return when(val parentView = getOriginalParent(v)) {
         null -> 0f

--- a/lib/android/app/src/main/java/com/reactnativenavigation/views/element/animators/FastImageBorderRadiusAnimator.kt
+++ b/lib/android/app/src/main/java/com/reactnativenavigation/views/element/animators/FastImageBorderRadiusAnimator.kt
@@ -11,23 +11,31 @@ import androidx.core.animation.doOnEnd
 import androidx.core.view.children
 import com.facebook.react.views.image.ReactImageView
 import com.facebook.react.views.view.ReactViewBackgroundDrawable
+import com.facebook.react.views.view.ReactViewGroup
 import com.reactnativenavigation.R
 import com.reactnativenavigation.options.SharedElementTransitionOptions
+import com.reactnativenavigation.react.ReactView
 import com.reactnativenavigation.utils.BorderRadiusOutlineProvider
 import com.reactnativenavigation.utils.ViewTags
+import com.reactnativenavigation.utils.borderRadius
+import com.reactnativenavigation.viewcontrollers.viewcontroller.overlay.OverlayLayout
+import java.lang.ClassCastException
+import java.lang.Exception
 
 class FastImageBorderRadiusAnimator(from: View, to: View) : PropertyAnimatorCreator<ImageView>(from, to) {
-    override fun shouldAnimateProperty(fromChild: ImageView, toChild: ImageView) =
-            Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP &&
-            fromChild !is ReactImageView
-                    && toChild !is ReactImageView
-                    && (getBorderRadius(from) != 0f || getBorderRadius(to) != 0f)
+    override fun shouldAnimateProperty(fromChild: ImageView, toChild: ImageView): Boolean {
+        return Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP &&
+                fromChild !is ReactImageView
+                && toChild !is ReactImageView
+                && (getInheritedBorderRadius(from) != 0f
+                || getInheritedBorderRadius(to) != 0f)
+    }
 
     @RequiresApi(Build.VERSION_CODES.LOLLIPOP)
     override fun create(options: SharedElementTransitionOptions): Animator {
         from as ImageView; to as ImageView
-        val fromRadius = getBorderRadius(from)
-        val toRadius = getBorderRadius(to)
+        val fromRadius = getInheritedBorderRadius(from)
+        val toRadius = getInheritedBorderRadius(to)
         val outlineProvider = BorderRadiusOutlineProvider(to, fromRadius)
         setInitialOutline(to, outlineProvider)
 
@@ -38,14 +46,6 @@ class FastImageBorderRadiusAnimator(from: View, to: View) : PropertyAnimatorCrea
         ).apply {
             doOnEnd { to.outlineProvider = null }
         }
-    }
-
-    private fun getBorderRadius(child: View): Float {
-        val parent = ViewTags.get<ViewGroup>(child, R.id.original_parent, child.parent as ViewGroup)
-        val parentIsUsedOnlyToDrawBorderRadiusOverImage = parent.childCount <= 1 || parent.children.contains(child)
-        val background = parent.background as? ReactViewBackgroundDrawable
-        return if (parentIsUsedOnlyToDrawBorderRadiusOverImage && background?.hasRoundedBorders() == true)
-            background.fullBorderRadius else 0f
     }
 
     @RequiresApi(Build.VERSION_CODES.LOLLIPOP)

--- a/lib/android/app/src/main/java/com/reactnativenavigation/views/element/animators/FastImageBorderRadiusAnimator.kt
+++ b/lib/android/app/src/main/java/com/reactnativenavigation/views/element/animators/FastImageBorderRadiusAnimator.kt
@@ -4,23 +4,12 @@ import android.animation.Animator
 import android.animation.ObjectAnimator
 import android.os.Build
 import android.view.View
-import android.view.ViewGroup
 import android.widget.ImageView
 import androidx.annotation.RequiresApi
 import androidx.core.animation.doOnEnd
-import androidx.core.view.children
 import com.facebook.react.views.image.ReactImageView
-import com.facebook.react.views.view.ReactViewBackgroundDrawable
-import com.facebook.react.views.view.ReactViewGroup
-import com.reactnativenavigation.R
 import com.reactnativenavigation.options.SharedElementTransitionOptions
-import com.reactnativenavigation.react.ReactView
 import com.reactnativenavigation.utils.BorderRadiusOutlineProvider
-import com.reactnativenavigation.utils.ViewTags
-import com.reactnativenavigation.utils.borderRadius
-import com.reactnativenavigation.viewcontrollers.viewcontroller.overlay.OverlayLayout
-import java.lang.ClassCastException
-import java.lang.Exception
 
 class FastImageBorderRadiusAnimator(from: View, to: View) : PropertyAnimatorCreator<ImageView>(from, to) {
     override fun shouldAnimateProperty(fromChild: ImageView, toChild: ImageView): Boolean {

--- a/lib/android/app/src/main/java/com/reactnativenavigation/views/element/animators/FastImageBorderRadiusAnimator.kt
+++ b/lib/android/app/src/main/java/com/reactnativenavigation/views/element/animators/FastImageBorderRadiusAnimator.kt
@@ -27,8 +27,7 @@ class FastImageBorderRadiusAnimator(from: View, to: View) : PropertyAnimatorCrea
         return Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP &&
                 fromChild !is ReactImageView
                 && toChild !is ReactImageView
-                && (getInheritedBorderRadius(from) != 0f
-                || getInheritedBorderRadius(to) != 0f)
+                && (getInheritedBorderRadius(from) != 0f || getInheritedBorderRadius(to) != 0f)
     }
 
     @RequiresApi(Build.VERSION_CODES.LOLLIPOP)


### PR DESCRIPTION
### The issue

The `FastImageBorderRadiusAnimator#shouldAnimateProperty` returned false in cases where the `FastImage` component is a child of another component that has a border radius. Example for such a use case:

```jsx
<View style={{ borderRadius: 30, overflow: "hidden" }}>
   <FastImage {...} />
</View>
```

In this case the animation would look like this. You can see that the borders will "make a jump" once the SET is finished:

https://user-images.githubusercontent.com/16821682/118120763-aebbd380-b3f0-11eb-879f-1348b11721a0.mp4

### The fix

I wrote a function that checks recursively:
* If the view is a ReactView -> try to get border radius from this react view
* If the view is a FastImageView -> try to get border radius from this FastImage view
* If it founds a border radius it returns


https://user-images.githubusercontent.com/16821682/118122398-183ce180-b3f3-11eb-8df8-e0f0202a2a3f.mp4



### Open questions

The recursive function fails when it reaches the root with the following error
```
java.lang.ClassCastException: android.view.ViewRootImpl cannot be cast to android.view.ViewGroup
```
currently, I try/catch this. Maybe there is a better way to check this (like `view is Overlay`) ?